### PR TITLE
Allow default .Site.Params.showAllPostsArchive - from https://github.com/monkeyWzr/hugo-theme-cactus/pull/84

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -23,7 +23,7 @@
     </li>
     {{ end }}
   </ul>
-  {{ if eq .Site.Params.showAllPostsArchive false }}
+  {{ if or (not .Site.Params.showAllPostsArchive) (eq .Site.Params.showAllPostsArchive false) }}
     {{ partial "pagination.html" . }}
   {{ end }}
 </div>


### PR DESCRIPTION
Allow, if .Site.Params.showAllPostsArchive is not set, the site to
function as if the variable has been set to false.

Fixes  monkeyWzr/hugo-theme-cactus#83

Signed-off-by: Jason Rogena <jason@rogena.me>
